### PR TITLE
Fix handling of AUTHORIZED and CONFIRMED payment statuses

### DIFF
--- a/controllers/front/api.php
+++ b/controllers/front/api.php
@@ -27,8 +27,8 @@ class moneybadgerAPIModuleFrontController extends ModuleFrontController
         }
 
         header('Content-Type: application/json');
-        $is_paid = $order->current_state === (int) Configuration::get('PS_OS_PAYMENT') ||
-        $order->current_state === (int) Configuration::get('PS_OS_OUTOFSTOCK_PAID');
+        $is_paid = (int) $order->current_state === (int) Configuration::get('PS_OS_PAYMENT') ||
+                    (int) $order->current_state === (int) Configuration::get('PS_OS_OUTOFSTOCK_PAID');
 
         echo json_encode(['is_paid' => $is_paid]);
     }

--- a/controllers/front/webhook.php
+++ b/controllers/front/webhook.php
@@ -49,7 +49,9 @@ class moneybadgerWebhookModuleFrontController extends ModuleFrontController
             case MoneyBadger::PAYMENT_STATUS_TIMEDOUT:
                 $order->setCurrentState((int) Configuration::get(MoneyBadger::ORDER_STATE_CAPTURE_TIMEDOUT));
                 break;
-            case (MoneyBadger::PAYMENT_STATUS_AUTHORIZED || MoneyBadger::PAYMENT_STATUS_CONFIRMED): // We expect CONFIRMED, but AUTHORIZED is also valid since we will request auto confirmation
+            case MoneyBadger::PAYMENT_STATUS_AUTHORIZED:
+            case MoneyBadger::PAYMENT_STATUS_CONFIRMED:
+                // We expect CONFIRMED, but AUTHORIZED is also valid since we will request auto confirmation
                 // mark the order as paid
                 if ($orderCurrentState !== (int) Configuration::get('PS_OS_OUTOFSTOCK_PAID')) {
                     $order->setCurrentState((int) Configuration::get('PS_OS_PAYMENT'));


### PR DESCRIPTION
The original issue with the switch statement was that using a logical OR (||) operator within a case statement
does not work as intended in PHP. Specifically, the expression `(MoneyBadger::PAYMENT_STATUS_AUTHORIZED || MoneyBadger::PAYMENT_STATUS_CONFIRMED)` would always evaluate to true if either of the constants is truth, which is not the correct way to match specific values in a switch case.

This would effectively turn that case into a catch-all, similar to a default case, because the condition becomes true for any non-false value of the variable being switched on, not just for the intended `PAYMENT_STATUS_AUTHORIZED` or `PAYMENT_STATUS_CONFIRMED` values.